### PR TITLE
Upgrade to Ubuntu 18.04 Bionic

### DIFF
--- a/bin/vars
+++ b/bin/vars
@@ -18,8 +18,11 @@ declare -a CUSTOMIZE_VARS=()
 # export IMAGE_NAME="livessh-ubuntu15.04"  # volume name of .iso
 # export RELEASE=wily
 # export IMAGE_NAME="livessh-ubuntu15.10"  # volume name of .iso
-export RELEASE=xenial
-export IMAGE_NAME="livessh-ubuntu16.04"  # volume name of .iso
+# export RELEASE=xenial
+# export IMAGE_NAME="livessh-ubuntu16.04"  # volume name of .iso
+export RELEASE=bionic
+export IMAGE_NAME="livessh-ubuntu18.04"  # volume name of .iso
+
 
 ####################
 ## apt-proxy config

--- a/customize.d/65-custom-software
+++ b/customize.d/65-custom-software
@@ -18,8 +18,6 @@ PACKAGES+=" linux-image-extra-virtual"
 # ibstat, etc. -- should replace with Mellanox packages
 PACKAGES+=" infiniband-diags"
 
-PACKAGES+=" emacs24-nox"
-
 PACKAGES+=" build-essential"
 
 PACKAGES+=" cryptsetup-bin lvm2"

--- a/data/customize.sh.in
+++ b/data/customize.sh.in
@@ -207,7 +207,6 @@ rm /etc/apt/apt.conf.d/docker-clean
 rm /etc/apt/apt.conf.d/docker-no-languages
 rm /etc/apt/apt.conf.d/docker-gzip-indexes  # without removing this, the livecd fails with an error about being unable to find index files
 rm etc/apt/apt.conf.d/docker-autoremove-suggests
-rm /etc/dpkg/dpkg.cfg.d/docker-apt-speedup
 
 ## XX: Does not restore /etc/apt/apt.conf.d/01autoremove-kernels
 


### PR DESCRIPTION
Required additional changes:
* 'emacs24-nox' package is no longer available
* No need to remove non-existing 'docker-apt-speedup' file any more

Notes:
* In order to use this image with `toram` boot option it is necessary
to also include `systemd.mask=tmp.mount`, more details can be found
here: https://bugs.launchpad.net/ubuntu/+source/casper/+bug/1755863
* In order to install and use `dnsmasq` I had to add an extra option
'DNSStubListener=no' to '/etc/systemd/resolved.conf' as other wise
`dnsmasq` is not able to bind socket for listening, more details
can be found here:
https://superuser.com/questions/1318220/ubuntu-18-04-disable-dnsmasq-base-and-enable-full-dnsmasq